### PR TITLE
Testing the removal of OWASP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
                 </executions>
             </plugin>
             <!-- owasp dependency check plugin -->
+            <!--
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
@@ -140,6 +141,7 @@
                     </execution>
                 </executions>
             </plugin>
+            -->
         </plugins>
     </build>
 


### PR DESCRIPTION
Removing OWASP as one of the dependencies is suffering from a CVE that blocks the build.